### PR TITLE
Current channel doesn't exist for push jobs server

### DIFF
--- a/packer-marketplace.json
+++ b/packer-marketplace.json
@@ -3,7 +3,7 @@
   "variables": {},
   "builders": [
     {
-      "ami_description": "AWS Native Chef Stack OS 5.1.0",
+      "ami_description": "AWS Native Chef Stack OS 5.1.1",
       "ami_groups": [
         "all"
       ],

--- a/scripts/marketplace_dl.sh
+++ b/scripts/marketplace_dl.sh
@@ -4,7 +4,7 @@ set -o errexit -o nounset -o pipefail
 VER_MARKETPLACE=5.1.0
 VER_CHEFSERVER=13.1.8
 VER_MANAGE=2.5.16
-VER_PJS=3.0.3
+VER_PJS=2.2.8
 VER_SUPERMARKET=3.3.7
 
 DL_BASEURL="https://packages.chef.io/files"
@@ -29,9 +29,7 @@ ln -s chef-server-core-${VER_CHEFSERVER}-1.el7.x86_64.rpm chef-server-core.rpm
 curl -s -OL ${DL_BASEURL}/${DL_CHANNEL}/chef-manage/${VER_MANAGE}/el/7/chef-manage-${VER_MANAGE}-1.el7.x86_64.rpm
 ln -s chef-manage-${VER_MANAGE}-1.el7.x86_64.rpm chef-manage.rpm
 
-# temporary switch PJS to current
-#curl -s -OL ${DL_BASEURL}/${DL_CHANNEL}/opscode-push-jobs-server/${VER_PJS}/el/7/opscode-push-jobs-server-${VER_PJS}-1.el7.x86_64.rpm
-curl -s -OL ${DL_BASEURL}/current/opscode-push-jobs-server/${VER_PJS}/el/7/opscode-push-jobs-server-${VER_PJS}-1.el7.x86_64.rpm
+curl -s -OL ${DL_BASEURL}/${DL_CHANNEL}/opscode-push-jobs-server/${VER_PJS}/el/7/opscode-push-jobs-server-${VER_PJS}-1.el7.x86_64.rpm
 ln -s opscode-push-jobs-server-${VER_PJS}-1.el7.x86_64.rpm push-jobs-server.rpm
 
 curl -s -OL ${DL_BASEURL}/${DL_CHANNEL}/supermarket/${VER_SUPERMARKET}/el/7/supermarket-${VER_SUPERMARKET}-1.el7.x86_64.rpm


### PR DESCRIPTION
These were the AMI changes required for v5.1.1 of AWS Native Chef Server and the AMIs are already published.