### PR TITLE
Update marketplace install versions and build AMIs based on CentOS 7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 
 ## Previous AMIs
+
+Published on 2020/04/21:
+
+```
+ap-northeast-1: ami-039176e6d6ff2ce53
+ap-northeast-2: ami-040b51960b42a9ae7
+ap-south-1: ami-068e104dfc81e21ed
+ap-southeast-1: ami-02d855c40c1b57453
+ap-southeast-2: ami-0a77b2aebbea2f130
+ca-central-1: ami-0388f5ac42716fba4
+eu-central-1: ami-039aef8fbfa1446c7
+eu-north-1: ami-0b7fbf4e46e9996ea
+eu-west-1: ami-0e41ecd9e5ddddfd5
+eu-west-2: ami-0d77212bfb8d309ae
+eu-west-3: ami-0cc8f93d4c1d25a78
+sa-east-1: ami-03947a94185a30029
+us-east-1: ami-0265357e9a3152543
+us-east-2: ami-0a657a17ea3dd0250
+us-west-1: ami-02737aa800421c21e
+us-west-2: ami-028cc18b3ac7c5dcc
+```
+
+Changelog:
+* Chef Workstation 0.17.5 / Puppet Agent 6.14.0 / Amazon SSM Agent 2.3.978.0
+* Docker 19.03.8-3.el7
+
+Published on 2019/10/07:
+
+```
+ap-northeast-1: ami-0943c71779148970f
+ap-northeast-2: ami-042714c24ecf25e26
+ap-south-1: ami-08cbb4e76dfee765f
+ap-southeast-1: ami-0f65ac71a3f129066
+ap-southeast-2: ami-0ff11e1be125ada2f
+ca-central-1: ami-0904037074b287caa
+eu-central-1: ami-0901dc2ff46fd73a2
+eu-north-1: ami-0f3c9a76407b25f84
+eu-west-1: ami-0581e1d8ead15c893
+eu-west-2: ami-0f415b06e749438de
+eu-west-3: ami-07eba3d943b8c05cd
+sa-east-1: ami-0bd26fc35cde37dca
+us-east-1: ami-02ddb83ff84ca592a
+us-east-2: ami-04e2458136bbbbaec
+us-west-1: ami-03ec171be9ffd4bdd
+us-west-2: ami-0d280b33e51a94243
+```
+
+Changelog:
+* CentOS 7.7 (kernel 3.10.0-1062.1.2.el7)
+* Switch on [Retpoline Spectre V2 mitigation to regain lost performance](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.7_release_notes/new_features#enhancement_kernel)
+* Chef Workstation 0.9.42 / Puppet Agent 6.10.0 / Amazon SSM Agent 2.3.714.0
+* Docker 19.03.2-3.el7
+
 Published on 2019/06/20:
 
 ```

--- a/README.md
+++ b/README.md
@@ -40,32 +40,30 @@ resource "aws_instance" "web" {
 ```
 
 ### Latest AMIs
-The latest AMIs were Published on 2019/10/07:
+The latest AMIs were Published on 2020/05/15
 
 ```
-ap-northeast-1: ami-0943c71779148970f
-ap-northeast-2: ami-042714c24ecf25e26
-ap-south-1: ami-08cbb4e76dfee765f
-ap-southeast-1: ami-0f65ac71a3f129066
-ap-southeast-2: ami-0ff11e1be125ada2f
-ca-central-1: ami-0904037074b287caa
-eu-central-1: ami-0901dc2ff46fd73a2
-eu-north-1: ami-0f3c9a76407b25f84
-eu-west-1: ami-0581e1d8ead15c893
-eu-west-2: ami-0f415b06e749438de
-eu-west-3: ami-07eba3d943b8c05cd
-sa-east-1: ami-0bd26fc35cde37dca
-us-east-1: ami-02ddb83ff84ca592a
-us-east-2: ami-04e2458136bbbbaec
-us-west-1: ami-03ec171be9ffd4bdd
-us-west-2: ami-0d280b33e51a94243
+ap-northeast-1: ami-04833e296a9bfc41a
+ap-northeast-2: ami-0558a6ce45a3f78ee
+ap-south-1: ami-01c18a17b3e07b5e3
+ap-southeast-1: ami-047e8076f4d853432
+ap-southeast-2: ami-0be404d991a0766d0
+ca-central-1: ami-0f9fa62621b3dfeac
+eu-central-1: ami-0e69c5560246b894f
+eu-north-1: ami-06f5c1e1ce3cdc148
+eu-west-1: ami-063589b5075ca9460
+eu-west-2: ami-033bcf62a7728d3e4
+eu-west-3: ami-025ba482c73ecb3cd
+sa-east-1: ami-0541b6e29d80e230a
+us-east-1: ami-08b2fc6637575c7c8
+us-east-2: ami-0a8d30e9659472c2f
+us-west-1: ami-0f6e519fe18711e88
+us-west-2: ami-0d83d024236b1d7e8
 ```
 
 Changelog:
-* CentOS 7.7 (kernel 3.10.0-1062.1.2.el7)
-* Switch on [Retpoline Spectre V2 mitigation to regain lost performance](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.7_release_notes/new_features#enhancement_kernel)
-* Chef Workstation 0.9.42 / Puppet Agent 6.10.0 / Amazon SSM Agent 2.3.714.0
-* Docker 19.03.2-3.el7
+* CentOS 7.8 (kernel kernel-3.10.0-1127.el7)
+* Chef Workstation 0.18.3 / Puppet Agent 6.15.0/ Amazon SSM Agent 2.3.1205.0
 
 ----
 

--- a/create_base_ami/create_base_ami.sh
+++ b/create_base_ami/create_base_ami.sh
@@ -6,8 +6,8 @@ set -o errexit -o nounset -o pipefail
 # - Launch a CentOS AMI, make sure it is a newer type that uses nvme disks (e.g. T3 or M5)
 #   - At launch time, specify attaching a secondary volume that is 8GB.  Do not set the secondary volume to delete on termination.
 # - Log in to your instance and become root (sudo -i)
-# - Update your instance, especially if it is not the latest (< 7.7):  yum upgrade -y and reboot
-# - run: curl -O https://raw.githubusercontent.com/irvingpop/packer-chef-highperf-centos7-ami/marketplace/create_base_ami.sh
+# - Update your instance, especially if it is not the latest (< 7.8):  yum upgrade -y and reboot
+# - run: curl -O https://raw.githubusercontent.com/chef-customers/packer-chef-highperf-centos7-ami/marketplace/create_base_ami.sh
 # - Find the volume using "lsblk". It's probaly named "nvme1n1"
 # - export DEVICE="/dev/nvme1n1" # export the DEVICE variable for this script
 # - bash -x create_base_ami.sh # start this script
@@ -52,7 +52,7 @@ mount "$PARTITION" "$ROOTFS"
 
 rpm --root="$ROOTFS" --initdb
 rpm --root="$ROOTFS" --nodeps -ivh \
-  https://mirrors.edge.kernel.org/centos/7.7.1908/os/x86_64/Packages/centos-release-7-7.1908.0.el7.centos.x86_64.rpm
+  https://mirrors.edge.kernel.org/centos/7.8.2003/os/x86_64/Packages/centos-release-7-8.2003.0.el7.centos.x86_64.rpm
 yum --installroot="$ROOTFS" --nogpgcheck -y update
 yum --installroot="$ROOTFS" --nogpgcheck -y groupinstall "Minimal Install" \
   --exclude="iwl*firmware" \

--- a/create_base_ami/packer.json
+++ b/create_base_ami/packer.json
@@ -15,6 +15,11 @@
               "X-Dept": "SCE",
               "X-Production": true
             },
+            "run_tags": {
+              "X-Contact": "tcate@chef.io",
+              "X-Dept": "SCE",
+              "X-Production": false
+            },
             "instance_type": "t3.large",
             "ssh_pty": "true",
             "source_ami": "ami-02eac2c0129f6376b",

--- a/create_base_ami/packer.json
+++ b/create_base_ami/packer.json
@@ -8,7 +8,7 @@
                 "us-west-2"
             ],
             "ami_name": "centos-7-minimal-install-{{isotime \"200601021504\"}}",
-            "ami_description": "Clean-room CentOS 7 minimal installation  https://github.com/irvingpop/packer-chef-highperf-centos7-ami",
+            "ami_description": "Clean-room CentOS 7 minimal installation  https://github.com/chef-customers/packer-chef-highperf-centos7-ami",
             "ssh_username": "centos",
             "tags": {
               "X-Contact": "tcate@chef.io",
@@ -22,7 +22,18 @@
             },
             "instance_type": "t3.large",
             "ssh_pty": "true",
-            "source_ami": "ami-02eac2c0129f6376b",
+            "source_ami_filter": {
+              "filters": {
+                "product-code": "aw0evgkw8e5c1q413zgy5pjce",
+                "virtualization-type": "hvm",
+                "name": "CentOS Linux 7 x86_64 HVM EBS ENA 2002*",
+                "root-device-type": "ebs"
+              },
+              "owners": [
+                "aws-marketplace"
+              ],
+              "most_recent": true
+            },
             "ami_virtualization_type": "hvm",
             "ebs_optimized": true,
             "ena_support": true,

--- a/packer-marketplace.json
+++ b/packer-marketplace.json
@@ -51,6 +51,11 @@
         "X-Dept": "SCE",
         "X-Production": true
       },
+      "run_tags": {
+        "X-Contact": "tcate@chef.io",
+        "X-Dept": "SCE",
+        "X-Production": false
+      },
       "type": "amazon-ebs"
     }
   ],

--- a/packer-marketplace.json
+++ b/packer-marketplace.json
@@ -3,11 +3,11 @@
   "variables": {},
   "builders": [
     {
-      "ami_description": "AWS Native Chef Stack OS 5.1.1",
+      "ami_description": "AWS Native Chef Stack OS 5.2.0",
       "ami_groups": [
         "all"
       ],
-      "ami_name": "aws-native-chef-server-5.1.{{isotime \"200601021504\"}}",
+      "ami_name": "aws-native-chef-server-5.2.{{isotime \"200601021504\"}}",
       "communicator": "ssh",
       "ebs_optimized": true,
       "ena_support": true,

--- a/packer.json
+++ b/packer.json
@@ -66,6 +66,11 @@
         "X-Dept": "SCE",
         "X-Production": true
       },
+      "run_tags": {
+        "X-Contact": "tcate@chef.io",
+        "X-Dept": "SCE",
+        "X-Production": false
+      },
       "type": "amazon-ebs"
     }
   ],

--- a/scripts/marketplace_dl.sh
+++ b/scripts/marketplace_dl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 set -o errexit -o nounset -o pipefail
 
-VER_MARKETPLACE=5.1.1
+VER_MARKETPLACE=5.2.0
 VER_CHEFSERVER=13.2.0
 VER_MANAGE=2.5.16
 VER_PJS=2.2.8

--- a/scripts/marketplace_dl.sh
+++ b/scripts/marketplace_dl.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -x
 set -o errexit -o nounset -o pipefail
 
-VER_MARKETPLACE=5.1.0
-VER_CHEFSERVER=13.1.8
+VER_MARKETPLACE=5.1.1
+VER_CHEFSERVER=13.2.0
 VER_MANAGE=2.5.16
 VER_PJS=2.2.8
-VER_SUPERMARKET=3.3.7
+VER_SUPERMARKET=3.3.20
 
 DL_BASEURL="https://packages.chef.io/files"
 DL_CHANNEL="stable"
@@ -21,9 +21,7 @@ curl -s -OL https://aws-native-chef-server.s3.amazonaws.com/${VER_MARKETPLACE}/f
 chmod +x main.sh
 
 echo ">>> Downloading and caching packages"
-# Temporarily switch chef-server to current
-#curl -s -OL ${DL_BASEURL}/${DL_CHANNEL}/chef-server/${VER_CHEFSERVER}/el/7/chef-server-core-${VER_CHEFSERVER}-1.el7.x86_64.rpm
-curl -s -OL ${DL_BASEURL}/current/chef-server/${VER_CHEFSERVER}/el/7/chef-server-core-${VER_CHEFSERVER}-1.el7.x86_64.rpm
+curl -s -OL ${DL_BASEURL}/${DL_CHANNEL}/chef-server/${VER_CHEFSERVER}/el/7/chef-server-core-${VER_CHEFSERVER}-1.el7.x86_64.rpm
 ln -s chef-server-core-${VER_CHEFSERVER}-1.el7.x86_64.rpm chef-server-core.rpm
 
 curl -s -OL ${DL_BASEURL}/${DL_CHANNEL}/chef-manage/${VER_MANAGE}/el/7/chef-manage-${VER_MANAGE}-1.el7.x86_64.rpm


### PR DESCRIPTION
Update to Chef Server 13.2.0, and switch Chef Server back to the stable channel. Will also have latest Automate 20200513205422 AIB. Also update Supermarket. 

`centos-7-minimal-install`, `aws-native-chef-server` and `chef-highperf-centos7` rebuilt on CentOS 7.8.2003

Added required tags to the EC2 instances used to create the AMIs via run_tags in the Packer definitions so the packer build can actually start.