### PR TITLE
Update images (May 2021)

### DIFF
--- a/create_base_ami/create_base_ami.sh
+++ b/create_base_ami/create_base_ami.sh
@@ -106,6 +106,8 @@ GRUB_CMDLINE_LINUX="console=tty0 crashkernel=auto console=ttyS0,115200"
 GRUB_DISABLE_RECOVERY="true"
 END
 
+yum --installroot="$ROOTFS" --nogpgcheck -y install kernel
+
 chroot "$ROOTFS" grub2-mkconfig -o /boot/grub2/grub.cfg
 chroot "$ROOTFS" grub2-install "$DEVICE"
 chroot "$ROOTFS" yum --nogpgcheck -y install cloud-init cloud-utils-growpart

--- a/create_base_ami/create_base_ami.sh
+++ b/create_base_ami/create_base_ami.sh
@@ -44,7 +44,11 @@ parted -s "$DEVICE" -- \
   set 1 boot on
 
 # Wait for device partition creation which happens asynchronously
-while [ ! -e "$PARTITION" ]; do sleep 1; done
+for ((ii=0;ii<60;++ii)) ; do
+  test -e "$PARTITION" && break
+  sleep 1
+done
+udevadm settle
 
 mkfs.xfs -f -L root "$PARTITION"
 mkdir -p "$ROOTFS"

--- a/create_base_ami/create_base_ami.sh
+++ b/create_base_ami/create_base_ami.sh
@@ -55,9 +55,7 @@ mkdir -p "$ROOTFS"
 mount "$PARTITION" "$ROOTFS"
 
 rpm --root="$ROOTFS" --initdb
-rpm --root="$ROOTFS" --nodeps -ivh \
-  https://mirrors.edge.kernel.org/centos/7.8.2003/os/x86_64/Packages/centos-release-7-8.2003.0.el7.centos.x86_64.rpm
-yum --installroot="$ROOTFS" --nogpgcheck -y update
+yum --installroot="$ROOTFS" --nogpgcheck -y --releasever=/ install centos-release
 yum --installroot="$ROOTFS" --nogpgcheck -y groupinstall "Minimal Install" \
   --exclude="iwl*firmware" \
   --exclude="NetworkManager*" \

--- a/create_base_ami/packer.json
+++ b/create_base_ami/packer.json
@@ -24,13 +24,12 @@
             "ssh_pty": "true",
             "source_ami_filter": {
               "filters": {
-                "product-code": "aw0evgkw8e5c1q413zgy5pjce",
                 "virtualization-type": "hvm",
-                "name": "CentOS Linux 7 x86_64 HVM EBS ENA 2002*",
+                "name": "CentOS 7.* x86_64",
                 "root-device-type": "ebs"
               },
               "owners": [
-                "aws-marketplace"
+                "125523088429"
               ],
               "most_recent": true
             },

--- a/files/chef_server_setup.sh
+++ b/files/chef_server_setup.sh
@@ -1,0 +1,89 @@
+#!/bin/bash -x
+
+# Provided variables that are required: STACKNAME, BUCKET, AWS_REGION
+test -n "${STACKNAME}" || exit 1
+test -n "${BUCKET}" || exit 1
+test -n "${AWS_REGION}" || exit 1
+test -n "${WAITHANDLE}" || exit 1
+
+# Determine if we are the bootstrap node
+# BOOTSTRAP_TAGS will be empty if not
+INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
+BOOTSTRAP_TAGS=`aws ec2 describe-tags --region $AWS_REGION --filter "Name=resource-id,Values=$INSTANCE_ID" --output=text | grep BootstrapAutoScaleGroup`
+
+# Check if the configs already exist in S3 - a sign that bootstrap already successfully happened once
+CONFIGS_EXIST=`aws s3 ls s3://${BUCKET}/${STACKNAME}/ | grep migration-level`
+
+# from this point on, exit on any errors and notify the waithandle that something bad happened
+set -e
+function error_exit {
+  echo "Error on line $1"
+  /opt/aws/bin/cfn-signal -e 1 -r "Error on line $1" "${WAITHANDLE}"
+  exit 1
+}
+trap 'error_exit $LINENO' ERR
+
+function download_config () {
+  aws s3 sync s3://${BUCKET}/${STACKNAME}/etc_opscode /etc/opscode --exclude "chef-server.rb"
+  mkdir -p /var/opt/opscode/upgrades
+  touch /var/opt/opscode/bootstrapped
+  aws s3 cp s3://${BUCKET}/${STACKNAME}/migration-level /var/opt/opscode/upgrades/
+}
+
+function upload_config () {
+  aws s3 sync /etc/opscode s3://${BUCKET}/${STACKNAME}/etc_opscode
+  aws s3 cp /var/opt/opscode/upgrades/migration-level s3://${BUCKET}/${STACKNAME}/
+}
+
+function server_reconfigure () {
+  chef-server-ctl reconfigure --chef-license=accept
+  chef-manage-ctl reconfigure --accept-license
+}
+
+function server_upgrade () {
+  chef-server-ctl reconfigure --chef-license=accept
+  chef-server-ctl upgrade
+  chef-server-ctl start
+  chef-manage-ctl reconfigure --accept-license
+}
+
+function prevent_dns_overload {
+  # erchef will constantly try to DNS lookup the bookshelf hostname, which is simply itself.
+  # as a workaround, we're just going to put the hostname
+  echo "`hostname -i` `hostname -f`" >> /etc/hosts
+}
+
+function push_jobs_configure () {
+	chef-server-ctl reconfigure --accept-license
+	opscode-push-jobs-server-ctl reconfigure
+	chef-server-ctl restart
+}
+
+# Here we go
+prevent_dns_overload
+
+# If we're not bootstrap OR a config already exists, sync down the rest of the secrets first before reconfiguring
+if [ -z "${BOOTSTRAP_TAGS}" ] || [ -n "${CONFIGS_EXIST}" ] ; then
+  echo "[INFO] configuring this node as a regular Chef frontend or restoring a Bootstrap"
+  download_config
+else
+  echo "[INFO] configuring this node as a Bootstrap Chef frontend"
+fi
+
+# Upgrade/Configure handler
+# If we're a bootstrap and configs already existed, upgrade
+if [ -n "${BOOTSTRAP_TAGS}" ] && [ -n "${CONFIGS_EXIST}" ] ; then
+  echo "[INFO] Looks like we're on a boostrap node that may need to be upgraded"
+  server_upgrade
+else
+  echo "[INFO] Running chef-server-ctl reconfigure"
+  server_reconfigure
+fi
+
+# the bootstrap instance should sync files after reconfigure, regardless if configs exist or not (upgrades)
+if [ -n "${BOOTSTRAP_TAGS}" ]; then
+  echo "[INFO] Configuring push jobs"
+  push_jobs_configure
+  echo "[INFO] syncing bootstrap secrets up to S3"
+  upload_config
+fi

--- a/packer-marketplace.json
+++ b/packer-marketplace.json
@@ -74,6 +74,11 @@
   ],
   "provisioners": [
     {
+      "type": "file",
+      "source": "files/chef_server_setup.sh",
+      "destination": "/tmp/chef_server_setup.sh"
+    },
+    {
       "type": "shell",
       "execute_command": "echo 'packer' | sudo -S env {{ .Vars }} {{ .Path }}",
       "environment_vars": [

--- a/packer-marketplace.json
+++ b/packer-marketplace.json
@@ -1,9 +1,22 @@
 {
   "min_packer_version": "1.3.0",
-  "variables": {},
+  "variables": {
+    "marketplace_version": "5.2.0",
+
+    "chef_server_version": "13.2.0",
+    "chef_manage_version": "2.5.16",
+    "push_jobs_version": "2.2.8",
+    "supermarket_version": "3.3.20",
+
+    "chef_server_url": "",
+    "chef_manage_url": "",
+    "push_jobs_url": "",
+    "supermarket_url": "",
+    "automate_url": ""
+  },
   "builders": [
     {
-      "ami_description": "AWS Native Chef Stack OS 5.2.0",
+      "ami_description": "AWS Native Chef Stack OS {{user `marketplace_version`}}",
       "ami_groups": [
         "all"
       ],
@@ -63,6 +76,18 @@
     {
       "type": "shell",
       "execute_command": "echo 'packer' | sudo -S env {{ .Vars }} {{ .Path }}",
+      "environment_vars": [
+        "VER_MARKETPLACE={{user `marketplace_version`}}",
+        "VER_CHEFSERVER={{user `chef_server_version`}}",
+        "VER_MANAGE={{user `chef_manage_version`}}",
+        "VER_PJS={{user `push_jobs_version`}}",
+        "VER_SUPERMARKET={{user `supermarket_version`}}",
+        "URL_CHEFSERVER={{user `chef_server_url`}}",
+        "URL_MANAGE={{user `chef_manage_url`}}",
+        "URL_PJS={{user `push_jobs_url`}}",
+        "URL_SUPERMARKET={{user `supermarket_url`}}",
+        "URL_AUTOMATE={{user `automate_url`}}"
+      ],
       "scripts": [
         "scripts/update_system.sh",
         "scripts/update_grub.sh",

--- a/packer-marketplace.json
+++ b/packer-marketplace.json
@@ -3,10 +3,10 @@
   "variables": {
     "marketplace_version": "5.2.0",
 
-    "chef_server_version": "13.2.0",
-    "chef_manage_version": "2.5.16",
+    "chef_server_version": "14.2.2",
+    "chef_manage_version": "3.0.11",
     "push_jobs_version": "2.2.8",
-    "supermarket_version": "3.3.20",
+    "supermarket_version": "3.4.1",
 
     "chef_server_url": "",
     "chef_manage_url": "",

--- a/scripts/marketplace_dl.sh
+++ b/scripts/marketplace_dl.sh
@@ -31,9 +31,9 @@ pushd /var/cache/marketplace
 echo ">>> Writing out a timestamp"
 echo "This package cache was generated for AWS Native Chef Stack marketplace ${VER_MARKETPLACE} on $(date)" > TIMESTAMP
 
-echo ">>> Downloading and caching install scripts"
-curl -s -OL https://aws-native-chef-server.s3.amazonaws.com/${VER_MARKETPLACE}/files/main.sh
-chmod +x main.sh
+echo ">>> Caching install scripts"
+install --mode=755 /tmp/chef_server_setup.sh ./main.sh
+rm -f /tmp/chef_server_setup.sh
 
 echo ">>> Downloading and caching packages"
 curl -s -OL "$URL_CHEFSERVER"


### PR DESCRIPTION
The following changes were needed in order to update images in May of 2021:

- Update CentOS packages:
    - Use CentOS 7 AMI from official distribution point (Red Hat deprecated and stopped updating AMIs in the marketplace).
    - Install the latest `centos-release` via `yum` instead of installing from a hard-coded URL then updating it.  When a new point-release of CentOS becomes GA, the old point-release is moved to vault.centos.org and the hard-coded URL stops working.  
    - Install a kernel.  The Linux kernel is not actually part of the "Minimal Install" group.  It was previously pulled in with the group as part of a package dependency that is no longer present.  

- Update `setuptools`.  `pip` was failing to install packages intermittently.  I eventually reproduced the issue and tracked it down to https://github.com/pypa/pypi-support/issues/978 .  The resolution is to update `pip` outside RPM.  (This is probably fixed upstream, by now.)

- Move `chef_server_setup.sh` from the `aws_native_chef_server` repo to this one.  `aws_native_chef_server` requires the AMIs built from this repo and this repo requires the setup script from `aws_native_chef_server`.  Moving the script eliminates the manual bootstrap that was needed to work around the circular dependency.

- Install newer versions of Chef Server, Manage, & Supermarket.

- Parameterize chef software versions and pass them to `marketplace_dl.sh` from packer.  Package versions change frequently.  This makes it easier for customers to build images with updated software than digging through scripts to find a hard-coded version. (Not strictly necessary for build.)

- Wait for `udev` to settle before calling `mkfs`.  I encountered a couple builds that failed with `mkfs` complaining that `/dev/nvme1n1p` did not exist.  I believe `udev` was still setting up the partition when the script's wait loop saw it, and there was a race between `udev` and `mkfs` afterward.  Waiting for `udev` to settle before calling `mkfs` appears to resolve the problem, but I cannot reliably reproduce the issue to be certain.